### PR TITLE
Use #include "file" for local includes

### DIFF
--- a/cdcacm.c
+++ b/cdcacm.c
@@ -17,9 +17,6 @@
  * along with this library.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <types.h>
-#include <ring.h>
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <errno.h>
@@ -32,6 +29,9 @@
 #include <libopencm3/stm32/f4/nvic.h>
 #include <libopencm3/stm32/pwr.h>
 #include <libopencmsis/core_cm3.h>
+
+#include "types.h"
+#include "ring.h"
 
 // Ring Buffer Size
 #define BUFFER_SIZE 1024

--- a/hosttest/streamtest.c
+++ b/hosttest/streamtest.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 
-#include <types.h>
-#include <symbol.h>
+#include "types.h"
+#include "symbol.h"
 
 u8 dat[] = {0xaa, 0xff, 0x00, 0x55, 0x33};
 

--- a/include/symbol.h
+++ b/include/symbol.h
@@ -1,7 +1,7 @@
 #ifndef __SYMBOL_H
 #define __SYMBOL_H
 
-#include <types.h>
+#include "types.h"
 
 #define SQRT2_INV 0.70710678118f
 

--- a/ring.c
+++ b/ring.c
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <types.h>
-#include <ring.h>
+#include "types.h"
+#include "ring.h"
 
 void ring_init(struct ring *ring, u8 * buf, ring_size_t size)
 {

--- a/symbol.c
+++ b/symbol.c
@@ -1,8 +1,9 @@
 /*
  * This file contains implementations for some basic symbol streams,
  */
-#include <symbol.h>
 #include <stdint.h>
+
+#include "symbol.h"
 
 struct symbol bpsk_lookup[] = {
 	{


### PR DESCRIPTION
The #include <file> format is intended for system includes, which for
this project would encompass the C standard library and libopencm3.

The other header files should be considered 'local' includes, which are
written directly for this application.

Also, move local includes to after system includes.
