### PR TITLE
Convolution refactor and test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 ## along with this library.  If not, see <http://www.gnu.org/licenses/>.
 ##
 
-OBJS = cdcacm.o ring.o symbol.o sample.o dac.o
+OBJS = convolution.o cdcacm.o ring.o symbol.o sample.o dac.o
 BINARY = main
 
 OPENCM3_DIR = libopencm3

--- a/convolution.c
+++ b/convolution.c
@@ -1,32 +1,6 @@
 #include "convolution.h"
 
 /*
- * TODO(mgyenik) lol this is dumb. Good thing we don't have to worry about
- * making it faster by being nice to cache lines or anything. This also needs
- * to use the symmetry of linear FIR filters to avoid half of the calculations
- */
-void convolve(float *in, float *out, float *fir, int in_len, int out_len, int fir_len)
-{
-	int i;
-	int j;
-
-	for (i = 0; i < out_len; i++) {
-		out[i] = 0.0f;
-		for (j = 0; j < fir_len; j++) {
-			int input_idx;
-
-			input_idx = i - j;
-			if (input_idx < 0)
-				continue;
-			if (input_idx > in_len)
-				continue;
-
-			out[i] += fir[j]*in[input_idx];
-		}
-	}
-}
-
-/*
  * Computes contributions of each input point to the output.
  * Useful for doing convolution from a stream instead of big array.
  */
@@ -49,4 +23,13 @@ float convolve_point(float *in, float *fir, int in_len, int out_idx, int fir_len
 	}
 
 	return out;
+}
+
+void convolve(float *in, float *out, float *fir, int in_len, int out_len,
+		int fir_len)
+{
+	int i;
+
+	for (i = 0; i < out_len; i++)
+		out[i] = convolve_point(in, fir, in_len, i, fir_len);
 }

--- a/convolution.c
+++ b/convolution.c
@@ -1,0 +1,52 @@
+#include "convolution.h"
+
+/*
+ * TODO(mgyenik) lol this is dumb. Good thing we don't have to worry about
+ * making it faster by being nice to cache lines or anything. This also needs
+ * to use the symmetry of linear FIR filters to avoid half of the calculations
+ */
+void convolve(float *in, float *out, float *fir, int in_len, int out_len, int fir_len)
+{
+	int i;
+	int j;
+
+	for (i = 0; i < out_len; i++) {
+		out[i] = 0.0f;
+		for (j = 0; j < fir_len; j++) {
+			int input_idx;
+
+			input_idx = i - j;
+			if (input_idx < 0)
+				continue;
+			if (input_idx > in_len)
+				continue;
+
+			out[i] += fir[j]*in[input_idx];
+		}
+	}
+}
+
+/*
+ * Computes contributions of each input point to the output.
+ * Useful for doing convolution from a stream instead of big array.
+ */
+float convolve_point(float *in, float *fir, int in_len, int out_idx, int fir_len)
+{
+	int j;
+	float out;
+
+	out = 0.0f;
+	for (j = 0; j < fir_len; j++) {
+		int input_idx;
+
+		input_idx = out_idx - j;
+		if (input_idx < 0)
+			continue;
+		if (input_idx > in_len)
+			continue;
+
+		out += fir[j]*in[input_idx];
+	}
+
+	return out;
+}

--- a/hosttest/.gitignore
+++ b/hosttest/.gitignore
@@ -1,2 +1,3 @@
 streamtest.so
 *.png
+convolutiontest

--- a/hosttest/Makefile
+++ b/hosttest/Makefile
@@ -3,6 +3,8 @@ all: streamtest
 TARGET = ..
 CFLAGS = -O3 -g3 -I../include/
 
+CONVOLUTION_CFLAGS := $(CFLAGS) -lm
+
 LIBOBJS := $(TARGET)/convolution.o $(TARGET)/symbol.o $(TARGET)/sample.o
 
 %.o: %.c
@@ -17,6 +19,9 @@ streamtest: streamtest.o $(LIBOBJS)
 
 streamtest.so: streamtest.pico $(LIBOBJS:.o=.pico)
 	gcc -shared -o $@ $^
+
+convolutiontest: convolutiontest.o $(LIBOBJS)
+	gcc $(CONVOLUTION_CFLAGS) -o $@ $^
 
 plotpng: plotdata
 	./pngplot.sh filter_test.png raw filtered
@@ -33,3 +38,4 @@ clean:
 	- rm -rf filtered
 	- rm streamtest
 	- rm streamtest.so
+	- rm convolutiontest

--- a/hosttest/Makefile
+++ b/hosttest/Makefile
@@ -3,6 +3,8 @@ all: streamtest
 TARGET = ..
 CFLAGS = -O3 -g3 -I../include/
 
+LIBOBJS := $(TARGET)/convolution.o $(TARGET)/symbol.o $(TARGET)/sample.o
+
 %.o: %.c
 	gcc -c $(CFLAGS) -o $@ $^
 
@@ -10,10 +12,10 @@ CFLAGS = -O3 -g3 -I../include/
 %.pico: %.c
 	gcc -c $(CFLAGS) -fpic -o $@ $^
 
-streamtest: streamtest.o $(TARGET)/symbol.o $(TARGET)/sample.o
+streamtest: streamtest.o $(LIBOBJS)
 	gcc $(CFLAGS) -o $@ $^
 
-streamtest.so: streamtest.pico $(TARGET)/symbol.pico $(TARGET)/sample.pico
+streamtest.so: streamtest.pico $(LIBOBJS:.o=.pico)
 	gcc -shared -o $@ $^
 
 plotpng: plotdata

--- a/hosttest/convolutiontest.c
+++ b/hosttest/convolutiontest.c
@@ -1,0 +1,52 @@
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+#include "convolution.h"
+
+#define ARRAY_LEN(_a)	(sizeof(_a)/sizeof(_a[0]))
+#define EPSILON 0.01f
+
+float in[] = {1, 2, 3, 4};
+float filter[] = {-1, 5, 3};
+float out[10];
+
+float expected[10] = {-1.0f, 3.0f, 10.0f, 17.0f, 29.0f, 12.0f, 0.0f, };
+
+static bool floateq(float a, float b)
+{
+	return fabsf(a - b) < EPSILON;
+}
+
+static void print_array(const char *name, float *arr, size_t len)
+{
+	int i;
+
+	printf("%-10s {", name);
+	for (i = 0; i < len; i++)
+		printf("%f, ", arr[i]);
+	puts("}");
+}
+
+int main(int argc, char **argv)
+{
+	int i;
+
+	print_array("Filter:", filter, ARRAY_LEN(filter));
+	print_array("Input:", in, ARRAY_LEN(in));
+
+	convolve(in, out, filter, ARRAY_LEN(in), ARRAY_LEN(out),
+			ARRAY_LEN(filter));
+
+	print_array("Output:", out, ARRAY_LEN(out));
+	print_array("Expected:", expected, ARRAY_LEN(expected));
+
+	for (i = 0; i < ARRAY_LEN(expected); i++) {
+		if (!floateq(out[i], expected[i])) {
+			puts("FAILED");
+			return -1;
+		}
+	}
+
+	return 0;
+}

--- a/include/convolution.h
+++ b/include/convolution.h
@@ -1,0 +1,10 @@
+#ifndef __CONVOLUTION_H
+#define __CONVOLUTION_H
+
+void convolve(float *in, float *out, float *fir, int in_len, int out_len,
+		int fir_len);
+
+float convolve_point(float *in, float *fir, int in_len, int out_idx,
+		int fir_len);
+
+#endif /* __CONVOLUTION_H */

--- a/include/sample.h
+++ b/include/sample.h
@@ -27,9 +27,7 @@ struct filter_stream {
 
 #define to_filter_stream(__ss) container_of(__ss, struct filter_stream, stream)
 
-float convolve_point(float *in, float *fir, int in_len, int out_idx, int fir_len);
 int fill_iq_bufs(struct symbol_stream *ss, float *i, float *q, int n);
-void convolve(float *in, float *out, float *fir, int in_len, int out_len, int fir_len);
 int init_filter_stream(struct filter_stream *fs, struct symbol_stream *ss, float *coeffs, int filter_len);
 int init_sample_hold(struct sample_hold *sh, struct symbol_stream *ss, int hold_count);
 

--- a/sample.c
+++ b/sample.c
@@ -1,30 +1,6 @@
+#include "convolution.h"
 #include "symbol.h"
 #include "sample.h"
-
-/*
- * Computes contributions of each input point to the output.
- * Useful for doing convolution from a stream instead of big array.
- */
-float convolve_point(float *in, float *fir, int in_len, int out_idx, int fir_len)
-{
-	int j;
-	float out;
-
-	out = 0.0f;
-	for (j = 0; j < fir_len; j++) {
-		int input_idx;
-
-		input_idx = out_idx - j;
-		if (input_idx < 0)
-			continue;
-		if (input_idx > in_len)
-			continue;
-
-		out += fir[j]*in[input_idx];
-	}
-
-	return out;
-}
 
 /* Takes n symbols from a stream and buffers them into separate buffers for each phase */
 int fill_iq_bufs(struct symbol_stream *ss, float *i, float *q, int n)
@@ -42,32 +18,6 @@ int fill_iq_bufs(struct symbol_stream *ss, float *i, float *q, int n)
 	}
 
 	return 0;
-}
-
-/*
- * TODO(mgyenik) lol this is dumb. Good thing we don't have to worry about
- * making it faster by being nice to cache lines or anything. This also needs
- * to use the symmetry of linear FIR filters to avoid half of the calculations
- */
-void convolve(float *in, float *out, float *fir, int in_len, int out_len, int fir_len)
-{
-	int i;
-	int j;
-
-	for (i = 0; i < out_len; i++) {
-		out[i] = 0.0f;
-		for (j = 0; j < fir_len; j++) {
-			int input_idx;
-
-			input_idx = i - j;
-			if (input_idx < 0)
-				continue;
-			if (input_idx > in_len)
-				continue;
-
-			out[i] += fir[j]*in[input_idx];
-		}
-	}
 }
 
 static int filter_emit_samples(struct sample_stream *ss, struct IQdata *bb_data)


### PR DESCRIPTION
Move the convolution routines to a dedicated file, since they are a distinct component which may get swapped out.

Refactor `convolve()` to use `convolve_point()` in its inner loop, to avoid code duplication.

Provide a `convolutiontest` hosttest to test the correctness of the convolution.
